### PR TITLE
build from git, factor code sign, remove i386 libs

### DIFF
--- a/build-app.sh
+++ b/build-app.sh
@@ -5,9 +5,7 @@
 
 APP_PATH=dist/HelloAppStore.app
 
-# The package signing identity corresponds to a "3rd Party Mac Developer Application"
-# certificate that resides within the Keychain Access application.
-SIGNING_IDENTITY="3rd Party Mac Developer Application: David Foster"
+mkdir -p dist build
 
 # Ensure building with Python 2.7
 # NOTE: If a different version of Python is desired, the Python patching steps
@@ -23,27 +21,36 @@ fi
 python setup.py py2app
 
 # Limit Universal Binaries to only contain the architechures {i386, x86_64},
-# since these are the only architechures permitted on the Mac App Store
+# since these are the only architechures permitted on the Mac App Store.  
+# In addition, remove all i386 items since all Macs models from early 2007 and 
+# newer have x86_64 support (aka Core 2 Duo or newer).  This will save 1.1MB
+# of space in Python's libraries alone, more from other frameworks..
 remove_arch () {
     lipo -output build/lipo.tmp -remove "$1" "$2" && mv build/lipo.tmp "$2"
 }
-remove_arch ppc7400 \
-    "$APP_PATH/Contents/Resources/lib/python2.7/lib-dynload/_sha256.so"
-remove_arch ppc7400 \
-    "$APP_PATH/Contents/Resources/lib/python2.7/lib-dynload/_sha512.so"
+for i in ${APP_PATH}/Contents/Resources/lib/python2.7/lib-dynload/* ; do
+    #remove_arch ppc ${i}
+    remove_arch i386 ${i}
+done
+
+source code-signing-config.sh
 
 # Sign the app, frameworks, and all helper tools as required by the Mac App Store.
 # (This example app has no helper tools.)
 # 
 # NOTE: Inner frameworks and tools must be signed before the outer app package.
 # NOTE: codesign with the -f option can incorrectly return exit status of 1
-codesign -s "$SIGNING_IDENTITY" -f \
-    "$APP_PATH/Contents/Frameworks/Python.framework/Versions/2.7"
-codesign -s "$SIGNING_IDENTITY" -f \
-    --entitlements src/app.entitlements \
-    "$APP_PATH/Contents/MacOS/HelloAppStore"
-codesign -s "$SIGNING_IDENTITY" -f \
-    --entitlements src/app.entitlements \
-    "$APP_PATH/Contents/MacOS/python"
+
+if [ ${DO_CODE_SIGNING} -eq 1 ] ; then
+    codesign -s "$SIGNING_IDENTITY" -f \
+        "$APP_PATH/Contents/Frameworks/Python.framework/Versions/2.7"
+    codesign -s "$SIGNING_IDENTITY" -f \
+        --entitlements src/app.entitlements \
+        "$APP_PATH/Contents/MacOS/HelloAppStore"
+    codesign -s "$SIGNING_IDENTITY" -f \
+        --entitlements src/app.entitlements \
+        "$APP_PATH/Contents/MacOS/python"
+fi
 
 exit 0
+# vim:ts=4:sts=4:sw=4:et

--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -4,17 +4,22 @@
 # using XCode's Application Loader tool
 # 
 
-# The package signing identity corresponds to a "3rd Party Mac Developer Installer"
-# certificate that resides within the Keychain Access application.
-SIGNING_IDENTITY="3rd Party Mac Developer Installer: David Foster"
-
 # Check prerequisites
 if [ ! -d dist/HelloAppStore.app ]; then
     echo "*** Must build app before building pkg."
     exit 1
 fi
 
+source code-signing-config.sh
+
+dash_dash_sign=''
+if [ ${DO_CODE_SIGNING} -eq 1 ] ; then
+    dash_dash_sign="--sign ${SIGNING_IDENTITY}"
+fi
+
 # NOTE: If having trouble with signing, debug by removing the --sign flag and
 #       trying to sign manually with the productsign command
 productbuild --component dist/HelloAppStore.app /Applications dist/HelloAppStore.pkg \
-    --sign "$SIGNING_IDENTITY"
+    $dash_dash_sign
+
+# vim:ts=4:sts=4:sw=4:et

--- a/code-signing-config.sh
+++ b/code-signing-config.sh
@@ -1,0 +1,10 @@
+# Configure code signing.
+
+# To enable signing, set this to "1".  Otherwise, no signing is done; useful
+# for local testing.
+DO_CODE_SIGNING=0
+
+# The package signing identity corresponds to a "3rd Party Mac Developer Application"
+# certificate that resides within the Keychain Access application.
+SIGNING_IDENTITY="3rd Party Mac Developer Application: David Foster"
+


### PR DESCRIPTION
1.   Make it build straight out of git, e.g. mkdir added, signing defaults off
2.   Factor out code signing to single config file
3.   The two libs in the original script don't contain PPC on my 10.10 box, so I removed the stripping for that.  Plus, I started stripping i386 since all Macs since 2007 have 64-bit.  So, this makes the binary much smaller (1.1MB just for Python).  Some of the Python libs don't even have i386, so not sure if this runs on 32-bit-only Macs anyway.
